### PR TITLE
Refactoring and minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /homf-junit.xml.html
 /docs/build/
 __pycache__
+/downloads/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,48 @@
 
 Homf is a tool for downloading artifacts from online services, like a ZipApp from GitHub Releases or a Wheel from PyPi.
 
-homf requires Python 3.8 or newer.
+Documentation: <https://homf.readthedocs.io/>
+
+If you have [pipx](https://pipx.pypa.io/) installed, it is recommended to
+use `pipx run homf ...` instead. You can use a shell alias, such as
+`alias homf='pipx run homf'`, to avoid having to remember this.
+
+The basic syntax is `homf SOURCE [OPTIONS] PACKAGE RELEASE`. `SOURCE` is one of `github` or `pypi`.
+For GitHub, `PACKAGE` is the repository and `RELEASE` is the tag used by GitHub Releases.
+For PyPi, `PACKAGE` is the package name on PyPi and `RELEASE` is the version number.
+
+By default, Homf downloads all files for the release into `./downloads`.
+
+See the [documentation](https://homf.readthedocs.io/) for details on `OPTIONS`.
+
+```
+$ homf github ppb/pursuedpybear
+INFO     Selected release 'v3.2.0 - The Bear Awakens!' as latest
+INFO     Downloaded 'downloads/examples.zip'
+INFO     Downloaded 'downloads/ppb-3.2.0-py3-none-any.whl'
+INFO     Downloaded 'downloads/ppb-3.2.0.tar.gz'
+$ tree downloads/
+downloads/
+├── examples.zip
+├── ppb-3.2.0-py3-none-any.whl
+└── ppb-3.2.0.tar.gz
+
+1 directory, 3 files
+$ rm -r downloads/
+$ homf pypi emanate
+INFO     Selected release '8.0.2' as latest
+INFO     Downloaded 'downloads/emanate-8.0.2-py3-none-any.whl'
+INFO     Downloaded 'downloads/emanate-8.0.2.tar.gz'
+$ tree downloads/
+downloads/
+├── emanate-8.0.2-py3-none-any.whl
+└── emanate-8.0.2.tar.gz
+
+1 directory, 2 files
+$
+```
+
+Homf requires Python 3.8 or newer.
 
 [build-status-img]: https://api.cirrus-ci.com/github/duckinator/homf.svg
 [build-status-link]: https://cirrus-ci.com/github/duckinator/homf

--- a/homf/api/github.py
+++ b/homf/api/github.py
@@ -43,6 +43,7 @@ def _get_release_info(repo, name, draft=False, prerelease=False):
             logging.info("Selected release '%s' as latest", release['name'])
         else:
             release = list(filter(lambda x: x['tag_name'] == name, releases))[0]
+            logging.info("Selected release '%s' as %s", release['name'], release['tag_name'])
 
     except (IndexError, ValueError) as e:
         raise RuntimeError(f"No such Github release: '{name}'") from e

--- a/homf/api/pypi.py
+++ b/homf/api/pypi.py
@@ -1,6 +1,7 @@
 import fnmatch
 import re
 from html.parser import HTMLParser
+import logging
 from typing import Dict
 from urllib.request import urlopen
 from . import asset_manager
@@ -78,6 +79,12 @@ def _get_download_info(base_url, package, release, file_pattern):
     parser = _SimplePypiParser()
     parser.feed(html)
     files = parser.files
+
+    versions = sorted(set(map(lambda x: x.split("-")[1].replace(".tar.gz", ""), files.keys())))
+
+    if release == "latest":
+        release = versions[-1]
+        logging.info("Selected release '%s' as latest", release)
 
     keys = list(files.keys()).copy()
     for name in keys:

--- a/homf/cli.py
+++ b/homf/cli.py
@@ -89,7 +89,7 @@ def _arg_parser():
 
     githubp = subparsers.add_parser("github",
                                       help="Download an artifact from GitHub.")
-    githubp.add_argument("--files", action="store", default="*.pyz",
+    githubp.add_argument("--files", action="store", default="*",
                           help="Comma-separated list of filenames to download."
                                "Supports wildcards (* = everything, ? = any single character).")
     githubp.add_argument("--directory", action="store", default="downloads",
@@ -104,7 +104,7 @@ def _arg_parser():
 
     pypip = subparsers.add_parser("pypi",
                                       help="Download an artifact from PyPi.")
-    pypip.add_argument("--files", action="store", default="*.pyz",
+    pypip.add_argument("--files", action="store", default="*",
                           help="Comma-separated list of filenames to download."
                                "Supports wildcards (* = everything, ? = any single character).")
     pypip.add_argument("--directory", action="store", default="downloads",

--- a/homf/cli.py
+++ b/homf/cli.py
@@ -137,6 +137,11 @@ def main(cmd_args=None):
         print(f"homf v{__version__}")
         sys.exit()
 
+    log_level = logging.INFO
+    if args.verbose:
+        log_level = logging.DEBUG
+    logging.basicConfig(format="%(levelname)-8s %(message)s", level=log_level)
+
     try:
         args.func(args)
     except RuntimeError as err:


### PR DESCRIPTION
- Default to downloading all files for the specified release.
- Have logs actually print to stdout.
- Handle `homf.api.pypi.download()` being given a release of "latest" (such as when you do `homf pypi PACKAGE` without a release).
- Add basic documentation to README.md.