### PR TITLE
Fix naming in docs & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ Homf requires Python 3.8 or newer.
 
 Bug reports and pull requests are welcome on GitHub at <https://github.com/duckinator/homf>.
 
-The code for Bork is available under the [MIT License](http://opensource.org/licenses/MIT).
+The code for Homf is available under the [MIT License](http://opensource.org/licenses/MIT).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-.. Emanate documentation master file, created by
+.. Homf documentation master file, created by
    sphinx-quickstart on Mon Feb 26 01:34:20 2024.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.


### PR DESCRIPTION
- **README: Bork → Homf**
- **docs: Emanate → Homf**
